### PR TITLE
Clean up a bit of code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ min-max-heap = "1.3.0"
 papaya = "0.2.3"
 hashbrown = "0.15.4"
 tinyvec = { version = "1.9.0", features = ["rustc_1_55"]}
-ordered-float = "5.0.0"
-slice-group-by = "0.3.1"
+ordered-float = "5.0.0" # only for bins
 
 [dev-dependencies]
 anyhow = "1.0.95"

--- a/src/distance/mod.rs
+++ b/src/distance/mod.rs
@@ -1,17 +1,13 @@
 use std::fmt;
 
 pub use binary_quantized_cosine::{BinaryQuantizedCosine, NodeHeaderBinaryQuantizedCosine};
-pub use binary_quantized_euclidean::{
-    BinaryQuantizedEuclidean, NodeHeaderBinaryQuantizedEuclidean,
-};
-pub use binary_quantized_manhattan::{
-    BinaryQuantizedManhattan, NodeHeaderBinaryQuantizedManhattan,
-};
+pub use binary_quantized_euclidean::BinaryQuantizedEuclidean;
+pub use binary_quantized_manhattan::BinaryQuantizedManhattan;
 use bytemuck::{Pod, Zeroable};
 pub use cosine::{Cosine, NodeHeaderCosine};
 pub use euclidean::{Euclidean, NodeHeaderEuclidean};
-pub use hamming::{Hamming, NodeHeaderHamming};
-pub use manhattan::{Manhattan, NodeHeaderManhattan};
+pub use hamming::Hamming;
+pub use manhattan::Manhattan;
 
 use crate::node::Item;
 use crate::unaligned_vector::{UnalignedVector, UnalignedVectorCodec};
@@ -23,12 +19,6 @@ mod cosine;
 mod euclidean;
 mod hamming;
 mod manhattan;
-
-// FIXME: move elsewhere, also currently unused
-fn new_leaf<D: Distance>(vec: Vec<f32>) -> Item<'static, D> {
-    let vector = UnalignedVector::from_vec(vec);
-    Item { header: D::new_header(&vector), vector }
-}
 
 /// A trait used by arroy to compute the distances,
 /// compute the split planes, and normalize user vectors.

--- a/src/ordered_float.rs
+++ b/src/ordered_float.rs
@@ -18,7 +18,7 @@ impl Eq for OrderedFloat {}
 
 impl PartialOrd for OrderedFloat {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.0.to_bits().partial_cmp(&other.0.to_bits())
+        Some(self.cmp(other))
     }
 }
 
@@ -30,8 +30,9 @@ impl Ord for OrderedFloat {
 
 #[cfg(test)]
 mod tests {
-    use crate::ordered_float::OrderedFloat;
     use proptest::prelude::*;
+
+    use crate::ordered_float::OrderedFloat;
 
     proptest! {
         #[test]

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -1,192 +1,16 @@
 use core::slice;
 use std::borrow::Cow;
-use std::fs::File;
-use std::io::{BufWriter, Write};
 use std::marker;
-use std::path::Path;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
 use hashbrown::HashMap;
 use heed::types::Bytes;
-use heed::{BytesDecode, BytesEncode, RoTxn};
-use memmap2::Mmap;
-use nohash::IntMap;
+use heed::{BytesDecode, RoTxn};
 use roaring::RoaringBitmap;
 
 use crate::internals::{Item, KeyCodec};
-use crate::key::{Key, Prefix, PrefixCodec};
+use crate::key::{Prefix, PrefixCodec};
 use crate::node::{Links, Node, NodeCodec};
-use crate::{Database, Distance, Error, ItemId, LayerId, Result};
-
-/// A structure to store the tree nodes out of the heed database.
-pub struct TmpNodes<DE> {
-    file: BufWriter<File>,
-    ids: Vec<ItemId>,
-    bounds: Vec<usize>,
-    deleted: RoaringBitmap,
-    remap_ids: IntMap<ItemId, ItemId>,
-    _marker: marker::PhantomData<DE>,
-}
-
-impl<'a, DE: BytesEncode<'a>> TmpNodes<DE> {
-    /// Creates an empty `TmpNodes`.
-    pub fn new() -> heed::Result<TmpNodes<DE>> {
-        Ok(TmpNodes {
-            file: tempfile::tempfile().map(BufWriter::new)?,
-            ids: Vec::new(),
-            bounds: vec![0],
-            deleted: RoaringBitmap::new(),
-            remap_ids: IntMap::default(),
-            _marker: marker::PhantomData,
-        })
-    }
-
-    /// Creates an empty `TmpNodes` in the defined folder.
-    pub fn new_in(path: &Path) -> heed::Result<TmpNodes<DE>> {
-        Ok(TmpNodes {
-            file: tempfile::tempfile_in(path).map(BufWriter::new)?,
-            ids: Vec::new(),
-            bounds: vec![0],
-            deleted: RoaringBitmap::new(),
-            remap_ids: IntMap::default(),
-            _marker: marker::PhantomData,
-        })
-    }
-
-    /// Add a new node in the file.
-    /// Items do not need to be ordered.
-    pub fn put(
-        // TODO move that in the type
-        &mut self,
-        item: ItemId,
-        data: &'a DE::EItem,
-    ) -> heed::Result<()> {
-        assert!(item != ItemId::MAX);
-        let bytes = DE::bytes_encode(data).map_err(heed::Error::Encoding)?;
-        self.file.write_all(&bytes)?;
-        let last_bound = self.bounds.last().unwrap();
-        self.bounds.push(last_bound + bytes.len());
-        self.ids.push(item);
-
-        // in the current algorithm, we should never insert a node that was deleted before
-        debug_assert!(!self.deleted.contains(item));
-
-        Ok(())
-    }
-
-    /// Remap the item id of an already inserted node to another node.
-    ///
-    /// Only applies to the nodes to insert. It won't interact with the to_delete nodes.
-    pub fn remap(&mut self, current: ItemId, new: ItemId) {
-        if current != new {
-            self.remap_ids.insert(current, new);
-        }
-    }
-
-    /// Delete the tmp_nodes and the node in the database.
-    pub fn remove(&mut self, item: ItemId) {
-        let deleted = self.deleted.insert(item);
-        debug_assert!(deleted, "Removed the same item with id {item} twice");
-    }
-
-    /// Converts it into a readers to read the nodes.
-    pub fn into_bytes_reader(self) -> Result<TmpNodesReader> {
-        let file = self.file.into_inner().map_err(|iie| iie.into_error())?;
-        // safety: No one should move our files around
-        let mmap = unsafe { Mmap::map(&file)? };
-        #[cfg(unix)]
-        mmap.advise(memmap2::Advice::Sequential)?;
-        Ok(TmpNodesReader {
-            mmap,
-            ids: self.ids,
-            bounds: self.bounds,
-            deleted: self.deleted,
-            remap_ids: self.remap_ids,
-        })
-    }
-}
-
-/// A reader of nodes stored in a file.
-pub struct TmpNodesReader {
-    mmap: Mmap,
-    ids: Vec<ItemId>,
-    bounds: Vec<usize>,
-    deleted: RoaringBitmap,
-    remap_ids: IntMap<ItemId, ItemId>,
-}
-
-impl TmpNodesReader {
-    pub fn to_delete(&self) -> impl Iterator<Item = ItemId> + '_ {
-        self.deleted.iter()
-    }
-
-    /// Returns an forward iterator over the nodes.
-    pub fn to_insert(&self) -> impl Iterator<Item = (ItemId, &[u8])> {
-        self.ids
-            .iter()
-            .zip(self.bounds.windows(2))
-            .filter(|(&id, _)| !self.deleted.contains(id))
-            .map(|(id, bounds)| match self.remap_ids.get(id) {
-                Some(new_id) => (new_id, bounds),
-                None => (id, bounds),
-            })
-            .map(|(id, bounds)| {
-                let [start, end] = [bounds[0], bounds[1]];
-                (*id, &self.mmap[start..end])
-            })
-    }
-}
-
-/// A concurrent ID generate that will never return the same ID twice.
-#[derive(Debug)]
-pub struct ConcurrentNodeIds {
-    /// The current tree node ID we should use if there is no other IDs available.
-    current: AtomicU32,
-    /// The total number of tree node IDs used.
-    used: AtomicU64,
-
-    /// A list of IDs to exhaust before picking IDs from `current`.
-    available: RoaringBitmap,
-    /// The current Nth ID to select in the bitmap.
-    select_in_bitmap: AtomicU32,
-    /// Tells if you should look in the roaring bitmap or if all the IDs are already exhausted.
-    look_into_bitmap: AtomicBool,
-}
-
-impl ConcurrentNodeIds {
-    /// Creates an ID generator returning unique IDs, avoiding the specified used IDs.
-    pub fn new(used: RoaringBitmap) -> ConcurrentNodeIds {
-        let last_id = used.max().map_or(0, |id| id + 1);
-        let used_ids = used.len();
-        let available = RoaringBitmap::from_sorted_iter(0..last_id).unwrap() - used;
-
-        ConcurrentNodeIds {
-            current: AtomicU32::new(last_id),
-            used: AtomicU64::new(used_ids),
-            select_in_bitmap: AtomicU32::new(0),
-            look_into_bitmap: AtomicBool::new(!available.is_empty()),
-            available,
-        }
-    }
-
-    /// Returns a new unique ID and increase the count of IDs used.
-    pub fn next(&self) -> Result<u32> {
-        if self.used.fetch_add(1, Ordering::Relaxed) > u32::MAX as u64 {
-            Err(Error::DatabaseFull)
-        } else if self.look_into_bitmap.load(Ordering::Relaxed) {
-            let current = self.select_in_bitmap.fetch_add(1, Ordering::Relaxed);
-            match self.available.select(current) {
-                Some(id) => Ok(id),
-                None => {
-                    self.look_into_bitmap.store(false, Ordering::Relaxed);
-                    Ok(self.current.fetch_add(1, Ordering::Relaxed))
-                }
-            }
-        } else {
-            Ok(self.current.fetch_add(1, Ordering::Relaxed))
-        }
-    }
-}
+use crate::{Database, Distance, ItemId, LayerId};
 
 /// A struture used to keep a list of the leaf nodes in the tree.
 ///
@@ -212,7 +36,7 @@ impl<'t, D: Distance> ImmutableItems<'t, D> {
         let mut map = HashMap::with_capacity(database.len(rtxn)? as usize);
         let mut constant_length = None;
 
-        let mut cursor = database
+        let cursor = database
             .remap_types::<PrefixCodec, Bytes>()
             .prefix_iter(rtxn, &Prefix::item(index))?
             .remap_key_type::<KeyCodec>();
@@ -249,7 +73,7 @@ impl<'t, D: Distance> ImmutableItems<'t, D> {
 unsafe impl<D> Sync for ImmutableItems<'_, D> {}
 
 /// A struture used to keep a list of all the links.
-/// It is safe to share between threads as the pointer are pointing
+/// It is safe to share between threads as the pointers are pointing
 /// in the mmapped file and the transaction is kept here and therefore
 /// no longer touches the database.
 pub struct ImmutableLinks<'t, D> {
@@ -280,10 +104,6 @@ impl<'t, D: Distance> ImmutableLinks<'t, D> {
         }
 
         Ok(ImmutableLinks { links, _marker: marker::PhantomData })
-    }
-
-    pub fn empty() -> Self {
-        Self { links: HashMap::default(), _marker: marker::PhantomData }
     }
 
     /// Returns the tree node identified by the given ID.

--- a/src/unaligned_vector/binary.rs
+++ b/src/unaligned_vector/binary.rs
@@ -74,7 +74,7 @@ impl UnalignedVectorCodec for Binary {
 }
 
 pub(super) fn from_slice_non_optimized(slice: &[f32]) -> Vec<u8> {
-    let mut output = Vec::with_capacity((slice.len() + PACKED_WORD_BITS - 1) / PACKED_WORD_BITS);
+    let mut output = Vec::with_capacity(slice.len().div_ceil(PACKED_WORD_BITS));
     for chunk in slice.chunks(PACKED_WORD_BITS) {
         let mut word: BitPackedWord = 0;
         let mut bits: u32;


### PR DESCRIPTION
This PR mostly removes a lot of warnings from `cargo check` and `cargo clippy`.

Very happy that you used `slice-group-by` ([my 350k/month crate](https://lib.rs/crates/slice-group-by)) but [I merged my work into the std](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.chunk_by), long time ago 😂

I was also a bit unclear on why you reimplemented `OrderedFloat`, and then I understood that we may want to make it safer and clearer (rename it). What do you think?

I have probably deleted a lot too much in the parallel.rs file, but, huh... we use git 😅