### PR TITLE
Introduce the `Writer::prepare_for_conversion` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,13 @@ name = "hannoy"
 description = "HNSW Approximate Nearest Neighbors in Rust, based on LMDB and optimized for memory usage"
 version = "0.0.2"
 repository = "https://github.com/nnethercott/hannoy"
-keywords = ["HNSW", "Graph-algorithms", "Vector-Search", "Store", "Nearest-Neighbours"]
+keywords = [
+    "HNSW",
+    "Graph-algorithms",
+    "Vector-Search",
+    "Store",
+    "Nearest-Neighbours",
+]
 categories = ["algorithms", "database", "data-structures", "science"]
 authors = [
     "Kerollmops <clement@meilisearch.com>",
@@ -30,7 +36,9 @@ tinyvec = { version = "1.9.0", features = ["rustc_1_55"] }
 
 [dev-dependencies]
 anyhow = "1.0.95"
+approx = "0.5.1"
 arbitrary = { version = "1.4.1", features = ["derive"] }
+arroy = "0.6.1"
 clap = { version = "4.5.24", features = ["derive"] }
 env_logger = "0.11.6"
 insta = "1.42.0"

--- a/src/node.rs
+++ b/src/node.rs
@@ -164,7 +164,24 @@ impl<'a, D: Distance> BytesDecode<'a> for NodeCodec<D> {
                 Ok(Node::Links(Links { links }))
             }
 
-            unknown => panic!("Did not recognize node tag type: {unknown:?}"),
+            [unknown_tag, ..] => {
+                Err(Box::new(InvalidNodeDecoding { unknown_tag: Some(*unknown_tag) }))
+            }
+            [] => Err(Box::new(InvalidNodeDecoding { unknown_tag: None })),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub struct InvalidNodeDecoding {
+    unknown_tag: Option<u8>,
+}
+
+impl fmt::Display for InvalidNodeDecoding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.unknown_tag {
+            Some(unknown_tag) => write!(f, "Invalid node decoding: unknown tag {unknown_tag}"),
+            None => write!(f, "Invalid node decoding: empty array of bytes"),
         }
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -316,7 +316,7 @@ impl<'t, D: Distance> Reader<'t, D> {
 
         let mut nns = Vec::with_capacity(opt.count);
         while let Some((OrderedFloat(f), id)) = neighbours.pop_min() {
-            if opt.candidates.is_some_and(|candidates| candidates.contains(id)) {
+            if opt.candidates.map_or(true, |candidates| candidates.contains(id)) {
                 nns.push((id, f));
             }
             if nns.len() == opt.count {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -18,6 +18,9 @@ use crate::unaligned_vector::UnalignedVector;
 use crate::version::{Version, VersionCodec};
 use crate::{Database, Error, ItemId, Key, MetadataCodec, Node, Prefix, PrefixCodec, Result};
 
+/// A good default value for the `ef` parameter.
+const DEFAULT_EF_SEARCH: usize = 100;
+
 /// Options used to make a query against an arroy [`Reader`].
 pub struct QueryBuilder<'a, D: Distance> {
     reader: &'a Reader<'a, D>,
@@ -233,7 +236,7 @@ impl<'t, D: Distance> Reader<'t, D> {
     ///
     /// You must provide the number of items you want to receive.
     pub fn nns(&self, count: usize) -> QueryBuilder<D> {
-        QueryBuilder { reader: self, candidates: None, count, ef: count }
+        QueryBuilder { reader: self, candidates: None, count, ef: DEFAULT_EF_SEARCH }
     }
 
     /// Get a generic read node from the database using the version of the database found while creating the reader.

--- a/src/tests/writer.rs
+++ b/src/tests/writer.rs
@@ -198,6 +198,67 @@ fn write_random_vectors_to_random_indexes() {
 }
 
 #[test]
+fn convert_from_arroy_to_hannoy() {
+    // let handle = create_database::<Euclidean>();
+    let _ = rayon::ThreadPoolBuilder::new().num_threads(1).build_global();
+    let dir = tempfile::tempdir().unwrap();
+    let env = unsafe { heed::EnvOpenOptions::new().map_size(200 * 1024 * 1024).open(dir.path()) }
+        .unwrap();
+    let mut wtxn = env.write_txn().unwrap();
+    let database: arroy::Database<arroy::distances::Cosine> =
+        env.create_database(&mut wtxn, None).unwrap();
+    wtxn.commit().unwrap();
+
+    let mut rng = rng();
+    let mut wtxn = env.write_txn().unwrap();
+
+    let mut db_indexes: Vec<u16> = (0..10).collect();
+    db_indexes.shuffle(&mut rng);
+
+    for index in db_indexes.iter().copied() {
+        let writer = arroy::Writer::new(database, index, 1024);
+
+        // We're going to write 100 vectors per index
+        for i in 0..100 {
+            let vector: [f32; 1024] = std::array::from_fn(|_| rng.gen());
+            writer.add_item(&mut wtxn, i, &vector).unwrap();
+        }
+        writer.builder(&mut rng).build(&mut wtxn).unwrap();
+    }
+    wtxn.commit().unwrap();
+
+    // Now it's time to convert the indexes
+
+    let mut wtxn = env.write_txn().unwrap();
+    let rtxn = env.read_txn().unwrap();
+    let database: crate::Database<Cosine> = env.open_database(&mut wtxn, None).unwrap().unwrap();
+
+    db_indexes.shuffle(&mut rng);
+
+    for index in db_indexes {
+        let pre_commit_arroy_reader =
+            arroy::Reader::<arroy::distances::Cosine>::open(&rtxn, index, database.remap_types())
+                .unwrap();
+
+        let writer = Writer::new(database, index, pre_commit_arroy_reader.dimensions());
+        writer.prepare_arroy_conversion(&mut wtxn).unwrap();
+        assert!(writer.need_build(&mut wtxn).unwrap());
+        writer.builder(&mut rng).build::<16, 32>(&mut wtxn).unwrap();
+
+        for result in pre_commit_arroy_reader.iter(&rtxn).unwrap() {
+            let (item_id, vector) = result.unwrap();
+            let reader = Reader::open(&wtxn, index, database).unwrap();
+            assert_eq!(reader.item_vector(&wtxn, item_id).unwrap().as_deref(), Some(&vector[..]));
+            let mut found = reader.nns(1).by_vector(&wtxn, &vector).unwrap();
+            dbg!(&found);
+            let (found_item_id, found_distance) = found.pop().unwrap();
+            assert_eq!(found_item_id, item_id);
+            approx::assert_abs_diff_eq!(found_distance, 0.0);
+        }
+    }
+}
+
+#[test]
 fn overwrite_one_item_incremental() {
     let handle = create_database::<Euclidean>();
     let mut rng = rng();

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -314,8 +314,8 @@ impl<D: Distance> Writer<D> {
             .with_entry_points(entry_points)
             .with_max_level(max_level);
 
-        let _stats = hnsw.build(to_insert, to_delete, self.database, self.index, wtxn, rng)?;
-        // dbg!("{:?}", stats);
+        let stats = hnsw.build(to_insert, to_delete, self.database, self.index, wtxn, rng)?;
+        tracing::info!("{stats:?}");
 
         tracing::debug!("write the metadata...");
         let metadata = Metadata {


### PR DESCRIPTION
This PR fixes #32 by introducing a method for starting to build the HNSW from the items (vectors) in an arroy format. It removes everything that is not an arroy/hannoy item (they have the same format) and lets the user call the `Writer::build` method once the preparation is done.

## To do
- [x] Add tests with an arroy database