### PR TITLE
Replace RoaringBitmap pushes by insertions instead

### DIFF
--- a/src/hnsw.rs
+++ b/src/hnsw.rs
@@ -262,7 +262,7 @@ impl<'a, D: Distance, const M: usize, const M0: usize> HnswBuilder<'a, D, M, M0>
             .collect();
 
         for &(item_id, _) in upper_layer {
-            ok_eps.push(item_id);
+            ok_eps.insert(item_id);
             self.add_in_layers_below(item_id, self.max_level);
         }
 
@@ -429,7 +429,7 @@ impl<'a, D: Distance, const M: usize, const M0: usize> HnswBuilder<'a, D, M, M0>
 
             candidates.push((Reverse(OrderedFloat(dist)), ep));
             res.push((OrderedFloat(dist), ep));
-            visited.push(ep);
+            visited.insert(ep);
         }
 
         while let Some(&(Reverse(OrderedFloat(f)), _)) = candidates.peek() {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -256,7 +256,7 @@ impl<'t, D: Distance> Reader<'t, D> {
 
             candidates.push((Reverse(OrderedFloat(dist)), ep));
             res.push((OrderedFloat(dist), ep));
-            visited.push(ep);
+            visited.insert(ep);
         }
 
         while let Some(&(Reverse(OrderedFloat(f)), _)) = candidates.peek() {
@@ -344,7 +344,7 @@ impl<'t, D: Distance> Reader<'t, D> {
             .remap_key_type::<KeyCodec>()
         {
             let (i, _) = result?;
-            item_ids.push(i.node.unwrap_item());
+            item_ids.insert(i.node.unwrap_item());
         }
         assert_eq!(item_ids, self.items);
 
@@ -357,7 +357,7 @@ impl<'t, D: Distance> Reader<'t, D> {
             .remap_key_type::<KeyCodec>()
         {
             let (k, node) = result?;
-            link_ids.push(k.node.item);
+            link_ids.insert(k.node.item);
 
             let Links { links } = match node {
                 Node::Links(links) => links,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -364,7 +364,7 @@ impl<D: Distance> Writer<D> {
                 return Err(Error::BuildCancelled);
             }
 
-            let inserted = updated_items.push(key.node.item);
+            let inserted = updated_items.insert(key.node.item);
             debug_assert!(inserted, "The keys should be sorted by LMDB");
             // SAFETY: Safe because we don't hold any reference to the database currently
             unsafe { updated_iter.del_current()? };
@@ -391,7 +391,7 @@ impl<D: Distance> Writer<D> {
             }
 
             let (i, _) = result?;
-            indices.push(i.node.unwrap_item());
+            indices.insert(i.node.unwrap_item());
         }
 
         Ok(indices)


### PR DESCRIPTION
This PR replaces all the `RoaringBitmap::push`es by `insert` calls. The [`push` method has been deprecated in the latest version of roaring-rs](https://github.com/RoaringBitmap/roaring-rs/pull/325) because it was confusing and replaced by the `try_push` method returning a result.