### PR TITLE
Normalize Hamming distance to [0,1] range

### DIFF
--- a/src/distance/hamming.rs
+++ b/src/distance/hamming.rs
@@ -43,7 +43,8 @@ impl Distance for Hamming {
     }
 
     fn distance(p: &Item<Self>, q: &Item<Self>) -> f32 {
-        hamming_bitwise_fast(p.vector.as_bytes(), q.vector.as_bytes())
+        let dist = hamming_bitwise_fast(p.vector.as_bytes(), q.vector.as_bytes());
+        dist / (p.vector.len() as f32)
     }
 
     fn norm_no_header(v: &UnalignedVector<Self::VectorCodec>) -> f32 {


### PR DESCRIPTION
Values between 0 and 1 are easier to interpret for end users. 

In the future we'll probably bring back [arroy's normalized distance](https://github.com/meilisearch/arroy/blob/main/src/distance/mod.rs#L59) which gets used only in the reader. 