### PR TITLE
loosely define the steppe version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rustc-hash = "2.1.1"
 thiserror = "2.0.9"
 tinyvec = { version = "1.9.0", features = ["rustc_1_55"] }
 tracing = "0.1.41"
-steppe = { version = "0.4.0", default-features = false }
+steppe = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.95"


### PR DESCRIPTION
In steppe 0.4.0 I defined the serde version a bit too precisely instead of just writing "1" as specified in their doc.
That causes issue when importing steppe in a project that requires another version of serde so I made a 0.4.1 of steppe that fixes the issue