### PR TITLE
Improve cold-start search latencies with madvise 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
           args: --all-features
       - uses: actions-rs/cargo@v1
         env:
-          # We encounter Os errors if trying to fetch too much memory in gh runners
+          # We encounter OS errors if trying to fetch too much memory in gh runners
           READER_AVAILABLE_MEMORY: 0
         with:
           command: test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,6 @@ jobs:
         rust:
           - stable
           - beta
-
     steps:
       - uses: actions/checkout@v1
       - uses: dtolnay/rust-toolchain@1.85
@@ -34,6 +33,9 @@ jobs:
           command: test
           args: --all-features
       - uses: actions-rs/cargo@v1
+        env:
+          # We encounter Os errors if trying to fetch too much memory in gh runners
+          READER_AVAILABLE_MEMORY: 0
         with:
           command: test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ thiserror = "2.0.9"
 tinyvec = { version = "1.9.0", features = ["rustc_1_55"] }
 tracing = "0.1.41"
 steppe = { version = "0.4", default-features = false }
+madvise = "0.1.0"
 
 [dev-dependencies]
 anyhow = "1.0.95"

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -24,7 +24,7 @@ use crate::{Database, Error, ItemId, Key, MetadataCodec, Node, Prefix, PrefixCod
 
 /// A good default value for the `ef` parameter.
 const DEFAULT_EF_SEARCH: usize = 100;
-const READER_AVAILABLE_MEMORY: &'static str = "READER_AVAILABLE_MEMORY";
+const READER_AVAILABLE_MEMORY: &str = "READER_AVAILABLE_MEMORY";
 const DEFAULT_AVAILABLE_MEMORY: usize = 100 * 1024 * 1024;
 
 #[cfg(not(test))]
@@ -190,7 +190,7 @@ impl<'t, D: Distance> Reader<'t, D> {
     ) -> Result<()> {
         let mut available_memory: usize = std::env::var(READER_AVAILABLE_MEMORY)
             .ok()
-            .and_then(|num| usize::from_str_radix(&num, 10).ok())
+            .and_then(|num| num.parse::<usize>().ok())
             .unwrap_or(DEFAULT_AVAILABLE_MEMORY);
 
         let page_size = page_size::get();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -208,7 +208,7 @@ impl<'t, D: Distance> Reader<'t, D> {
         let mut added = RoaringBitmap::new();
 
         for lvl in (1..=metadata.max_level).rev() {
-            for result in database.remap_data_type::<Bytes>().iter(&rtxn)? {
+            for result in database.remap_data_type::<Bytes>().iter(rtxn)? {
                 if available_memory < largest_alloc.load(Ordering::Relaxed) {
                     return Ok(());
                 }
@@ -228,13 +228,13 @@ impl<'t, D: Distance> Reader<'t, D> {
             if available_memory < largest_alloc.load(Ordering::Relaxed) {
                 return Ok(());
             }
-            if let Some(Node::Links(links)) = database.get(&rtxn, &Key::links(index, item, 0))? {
+            if let Some(Node::Links(links)) = database.get(rtxn, &Key::links(index, item, 0))? {
                 for l in links.iter() {
                     if !added.insert(l) {
                         continue;
                     }
                     if let Some(bytes) =
-                        database.remap_data_type::<Bytes>().get(&rtxn, &Key::item(index, l))?
+                        database.remap_data_type::<Bytes>().get(rtxn, &Key::item(index, l))?
                     {
                         available_memory -= madvise_page(bytes);
                         queue.push_back(l);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -9,7 +9,7 @@ use heed::RoTxn;
 use madvise::AccessPattern;
 use min_max_heap::MinMaxHeap;
 use roaring::RoaringBitmap;
-use tracing::{error, warn};
+use tracing::warn;
 
 use crate::distance::Distance;
 use crate::hnsw::ScoredLink;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -194,7 +194,7 @@ impl<'t, D: Distance> Reader<'t, D> {
             .and_then(|num| num.parse::<usize>().ok())
             .unwrap_or(DEFAULT_AVAILABLE_MEMORY);
 
-        if available_memory<page_size{
+        if available_memory < page_size {
             return Ok(());
         }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -181,7 +181,7 @@ impl<'t, D: Distance> Reader<'t, D> {
     }
 
     /// Instructs kernel to fetch nodes based on a fixed memory budget. It's OK for this operation
-    /// to fail, it's just integral for search to work.
+    /// to fail, it's not integral for search to work.
     fn prefetch_graph(
         rtxn: &RoTxn,
         database: &Database<D>,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -188,12 +188,16 @@ impl<'t, D: Distance> Reader<'t, D> {
         index: u16,
         metadata: &Metadata,
     ) -> Result<()> {
+        let page_size = page_size::get();
         let mut available_memory: usize = std::env::var(READER_AVAILABLE_MEMORY)
             .ok()
             .and_then(|num| num.parse::<usize>().ok())
             .unwrap_or(DEFAULT_AVAILABLE_MEMORY);
 
-        let page_size = page_size::get();
+        if available_memory<page_size{
+            return Ok(());
+        }
+
         let largest_alloc = AtomicUsize::new(0);
 
         let madvise_page = |item: &[u8]| -> Result<usize> {


### PR DESCRIPTION
Every search uses vectors from the graph entry points. We can hint to the kernel that we'll need need them (and their links), and even iterate through the graph deterministically to fetch other nodes we'll probably need as well. 

Doing this can save us a couple ms on cold-start retrievals