### PR TITLE
Add method to vector codec trait for quantization info

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -201,7 +201,7 @@ impl<'t, D: Distance> Reader<'t, D> {
 
         // adjusted length in memory of a vector
         let item_length = (metadata.dimensions as usize)
-            .div_ceil(<D::VectorCodec as UnalignedVectorCodec>::quantized_word_size());
+            .div_ceil(<D::VectorCodec as UnalignedVectorCodec>::word_size());
 
         let madvise_page = |item: &[u8]| -> Result<usize> {
             let start_ptr = item.as_ptr() as usize;

--- a/src/unaligned_vector/binary.rs
+++ b/src/unaligned_vector/binary.rs
@@ -71,6 +71,10 @@ impl UnalignedVectorCodec for Binary {
     fn is_zero(vec: &UnalignedVector<Self>) -> bool {
         vec.as_bytes().iter().all(|b| *b == 0)
     }
+
+    fn quantized_word_size() -> usize {
+        PACKED_WORD_BITS
+    }
 }
 
 pub(super) fn from_slice_non_optimized(slice: &[f32]) -> Vec<u8> {

--- a/src/unaligned_vector/binary.rs
+++ b/src/unaligned_vector/binary.rs
@@ -72,7 +72,7 @@ impl UnalignedVectorCodec for Binary {
         vec.as_bytes().iter().all(|b| *b == 0)
     }
 
-    fn quantized_word_size() -> usize {
+    fn word_size() -> usize {
         PACKED_WORD_BITS
     }
 }

--- a/src/unaligned_vector/binary_quantized.rs
+++ b/src/unaligned_vector/binary_quantized.rs
@@ -72,7 +72,7 @@ impl UnalignedVectorCodec for BinaryQuantized {
         vec.as_bytes().iter().all(|b| *b == 0)
     }
 
-    fn quantized_word_size() -> usize {
+    fn word_size() -> usize {
         QUANTIZED_WORD_BITS
     }
 }

--- a/src/unaligned_vector/binary_quantized.rs
+++ b/src/unaligned_vector/binary_quantized.rs
@@ -71,6 +71,10 @@ impl UnalignedVectorCodec for BinaryQuantized {
     fn is_zero(vec: &UnalignedVector<Self>) -> bool {
         vec.as_bytes().iter().all(|b| *b == 0)
     }
+
+    fn quantized_word_size() -> usize {
+        QUANTIZED_WORD_BITS
+    }
 }
 
 pub(super) fn from_slice_non_optimized(slice: &[f32]) -> Vec<u8> {

--- a/src/unaligned_vector/mod.rs
+++ b/src/unaligned_vector/mod.rs
@@ -45,6 +45,11 @@ pub trait UnalignedVectorCodec: std::borrow::ToOwned + Sized {
 
     /// Returns true if all the elements in the vector are equal to 0.
     fn is_zero(vec: &UnalignedVector<Self>) -> bool;
+
+    /// Returns the bit-packing size if quantized
+    fn quantized_word_size() -> usize {
+        1
+    }
 }
 
 /// A wrapper struct that is used to read unaligned vectors directly from memory.

--- a/src/unaligned_vector/mod.rs
+++ b/src/unaligned_vector/mod.rs
@@ -47,7 +47,7 @@ pub trait UnalignedVectorCodec: std::borrow::ToOwned + Sized {
     fn is_zero(vec: &UnalignedVector<Self>) -> bool;
 
     /// Returns the bit-packing size if quantized
-    fn quantized_word_size() -> usize {
+    fn word_size() -> usize {
         1
     }
 }


### PR DESCRIPTION
Fixes over-estimation of vector size in the vector pre-fetching when using quantized vectors