### PR TITLE
Uses explore factor instead of count to stop the search

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -697,7 +697,7 @@ impl<D: Distance> Reader<D> {
                 }
 
                 visitor.eps = vec![id];
-                visitor.ef = opt.ef - neighbours.len();
+                visitor.ef = opt.ef.saturating_sub(neighbours.len());
 
                 let more_nns =
                     return_if_cancelled!(visitor.visit(query, self, rtxn, &mut path, cancel_fn)?);


### PR DESCRIPTION
In the current implementation, the exploration factor (ef) is not really taken into account when fetching the neighbours because the visitor exploration factor is not based on it but is based on the `count` parameter.

This PR will:
- Base the visitor exploration factor (`visitor.ef`) on the `QueryBuilder`'s exploration factor (`opt.ef`)
- Base the stop condition on the `QueryBuilder`'s exploration factor (`opt.ef`)


The Bug has been detected with a customer that were searching documents 10 by 10 which was amplifying the issue.
