### PR TITLE
by_items

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -516,21 +516,23 @@ impl PyReader {
     }
 
     /// Retrieve similar items for each of the batched item IDs.
-    /// Returns `None` if the item(s) is not in in the database
+    // Paralle version of by_items
+    // Returns None if the item(s) is not in the database
     #[pyo3(signature = (items, n=10, ef_search=200))]
     fn by_items(
         &self,
         items: Vec<ItemId>,
         n: usize,
         ef_search: usize,
-    ) -> PyResult<Vec<Option<Vec<(ItemId, f32)>>>> {
-        let rtxn = &self.rtxn;
-        let found = 
-            hnsw_search!(&self.dyn_reader, |r| r.nns(n).ef_search(ef_search).by_items(&rtxn, &items))
-                .map_err(h2py_err)?;
-        Ok(found.into_iter().map(|opt| opt.map(|s| s.into_nns())).collect())
+    ) -> PyResult<Vec<Option<Vec<(ItemId, f32)>>>>{
+        let env = ENV.get().ok_or_else( || PyRuntimeError::new_err("No environment"))?;
+        let found = hnsw_search!(&self.dyn_reader, |r| r.par_by_items(env, &items, n, ef_search)).map_err(h2py_err)?;
+        let results: Vec<Option<Vec<(ItemId, f32)>>> = found.into_iter().map(|opt| opt.map(|s| s.into_nns())).collect();
+        Ok(results)
     }
+
 }
+
 
 fn h2py_err<E: Into<crate::error::Error>>(e: E) -> PyErr {
     match e.into() {

--- a/src/python.rs
+++ b/src/python.rs
@@ -515,8 +515,29 @@ impl PyReader {
         Ok(found.map(|s| s.into_nns()))
     }
 
+        /// Sequential batch — TEMPORARY, for benchmarking against parallel `by_items`.
+    #[pyo3(signature = (items, n=10, ef_search=200))]
+    fn by_items_seq(
+        &self,
+        items: Vec<ItemId>,
+        n: usize,
+        ef_search: usize,
+    ) -> PyResult<Vec<Option<Vec<(ItemId, f32)>>>> {
+        let rtxn = &self.rtxn;
+        let found = items
+            .iter()
+            .map(|&item| {
+                hnsw_search!(&self.dyn_reader, |r| r
+                    .nns(n)
+                    .ef_search(ef_search)
+                    .by_item(&rtxn, item))
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(h2py_err)?;
+        Ok(found.into_iter().map(|opt| opt.map(|s| s.into_nns())).collect())
+    }
+
     /// Retrieve similar items for each of the batched item IDs.
-    // Paralle version of by_items
     // Returns None if the item(s) is not in the database
     #[pyo3(signature = (items, n=10, ef_search=200))]
     fn by_items(
@@ -526,7 +547,7 @@ impl PyReader {
         ef_search: usize,
     ) -> PyResult<Vec<Option<Vec<(ItemId, f32)>>>>{
         let env = ENV.get().ok_or_else( || PyRuntimeError::new_err("No environment"))?;
-        let found = hnsw_search!(&self.dyn_reader, |r| r.par_by_items(env, &items, n, ef_search)).map_err(h2py_err)?;
+        let found = hnsw_search!(&self.dyn_reader, |r| r.by_items(env, &items, n, ef_search)).map_err(h2py_err)?;
         let results: Vec<Option<Vec<(ItemId, f32)>>> = found.into_iter().map(|opt| opt.map(|s| s.into_nns())).collect();
         Ok(results)
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -514,6 +514,22 @@ impl PyReader {
                 .map_err(h2py_err)?;
         Ok(found.map(|s| s.into_nns()))
     }
+
+    /// Retrieve similar items for each of the batched item IDs.
+    /// Returns `None` if the item(s) is not in in the database
+    #[pyo3(signature = (items, n=10, ef_search=200))]
+    fn by_items(
+        &self,
+        items: Vec<ItemId>,
+        n: usize,
+        ef_search: usize,
+    ) -> PyResult<Vec<Option<Vec<(ItemId, f32)>>>> {
+        let rtxn = &self.rtxn;
+        let found = 
+            hnsw_search!(&self.dyn_reader, |r| r.nns(n).ef_search(ef_search).by_items(&rtxn, &items))
+                .map_err(h2py_err)?;
+        Ok(found.into_iter().map(|opt| opt.map(|s| s.into_nns())).collect())
+    }
 }
 
 fn h2py_err<E: Into<crate::error::Error>>(e: E) -> PyErr {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -67,7 +67,7 @@ pub struct QueryBuilder<'a, D: Distance> {
 }
 
 impl<'a, D: Distance> QueryBuilder<'a, D> {
-    /// Returns the closests items from `item`.
+    /// Returns the closest items from `item`.
     ///
     /// See also [`Self::by_vector`].
     ///
@@ -86,6 +86,21 @@ impl<'a, D: Distance> QueryBuilder<'a, D> {
             }
             None => None,
         })
+    }
+
+    /// Returns the closest items for each id sent via batched items.
+    ///
+    /// Alternative to calling by_item on each id separately.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use hannoy::{Reader, distances::Euclidean};
+    /// # let (reader, rtxn): (Reader<Euclidean>, heed::RoTxn) = todo!();
+    /// reader.nns(20).by_items(&rtxn, &[5, 6, 7]);
+    /// ```
+    pub fn by_items(&self, rtxn: &RoTxn, items: &[ItemId]) -> Result<Vec<Option<Searched>>> {
+        // searches run sequentially but could be parallelized
+        items.iter().map(|&item| self.by_item (rtxn, item)).collect()
     }
 
     /// Returns as many nearest neighbours to the query as possible before `cancel_fn` evaluates to

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4,7 +4,7 @@ use std::marker;
 use std::num::NonZeroUsize;
 
 use heed::types::DecodeIgnore;
-use heed::RoTxn;
+use heed::{Env, RoTxn, WithoutTls};
 use min_max_heap::MinMaxHeap;
 use roaring::RoaringBitmap;
 
@@ -98,10 +98,10 @@ impl<'a, D: Distance> QueryBuilder<'a, D> {
     /// # let (reader, rtxn): (Reader<Euclidean>, heed::RoTxn) = todo!();
     /// reader.nns(20).by_items(&rtxn, &[5, 6, 7]);
     /// ```
-    pub fn by_items(&self, rtxn: &RoTxn, items: &[ItemId]) -> Result<Vec<Option<Searched>>> {
-        // searches run sequentially but could be parallelized
-        items.iter().map(|&item| self.by_item (rtxn, item)).collect()
-    }
+    // pub fn by_items(&self, rtxn: &RoTxn, items: &[ItemId]) -> Result<Vec<Option<Searched>>> {
+    //     // searches run sequentially but could be parallelized
+    //     items.iter().map(|&item| self.by_item (rtxn, item)).collect()
+    // }
 
     /// Returns as many nearest neighbours to the query as possible before `cancel_fn` evaluates to
     /// true, and indicates whether or not search terminated early.
@@ -632,6 +632,37 @@ impl<D: Distance> Reader<D> {
             linear_below: DEFAULT_LINEAR_SCAN_THRESHOLD,
             linear_below_ratio: DEFAULT_LINEAR_SCAN_THRESHOLD_RATIO,
         }
+    }
+
+    /// Parallel and batch version of items
+    ///
+    /// Returns the closest items for each id sent via batched items
+    ///
+    /// Alternative to calling by_item on each id separately. 
+    /// Returns `None` if that id is not in the database
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use hannoy::{Reader, distances::Euclidean};
+    /// # use heed::{Env, WithoutTLs};
+    /// # let (reader, env): (Reader<Euclidean>, Env<WithoutTLs>) = todo!();
+    /// reader.par_by_items(&env, &[5, 6, 7], 10, 200);
+
+    pub fn par_by_items(&self, env: &Env<WithoutTls>, items: &[ItemId], 
+                        n: usize, ef_search: usize) -> Result<Vec<Option<Searched>>>  where D: Sync, {
+        
+        use rayon::prelude::*;
+        // going with opening one read transaction per worker
+        let num_threads = rayon::current_num_threads() + 1;
+        let (sender, pool) = crossbeam_channel::bounded(num_threads);
+        for _ in 0..num_threads {
+            sender.try_send(env.read_txn()?).unwrap();
+        }
+        let txns: thread_local::ThreadLocal<RoTxn<WithoutTls>> = thread_local::ThreadLocal::new();
+        items.par_iter().map(|&item| 
+            { 
+                let rtxn = txns.get_or( || pool.try_recv().unwrap());
+                self.nns(n).ef_search(ef_search).by_item(rtxn, item)}).collect()
     }
 
     fn should_linear_scan(&self, opt: &QueryBuilder<D>) -> bool {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -88,21 +88,6 @@ impl<'a, D: Distance> QueryBuilder<'a, D> {
         })
     }
 
-    /// Returns the closest items for each id sent via batched items.
-    ///
-    /// Alternative to calling by_item on each id separately.
-    ///
-    /// # Examples
-    /// ```no_run
-    /// # use hannoy::{Reader, distances::Euclidean};
-    /// # let (reader, rtxn): (Reader<Euclidean>, heed::RoTxn) = todo!();
-    /// reader.nns(20).by_items(&rtxn, &[5, 6, 7]);
-    /// ```
-    // pub fn by_items(&self, rtxn: &RoTxn, items: &[ItemId]) -> Result<Vec<Option<Searched>>> {
-    //     // searches run sequentially but could be parallelized
-    //     items.iter().map(|&item| self.by_item (rtxn, item)).collect()
-    // }
-
     /// Returns as many nearest neighbours to the query as possible before `cancel_fn` evaluates to
     /// true, and indicates whether or not search terminated early.
     ///
@@ -634,9 +619,7 @@ impl<D: Distance> Reader<D> {
         }
     }
 
-    /// Parallel and batch version of items
-    ///
-    /// Returns the closest items for each id sent via batched items
+    /// Returns the closest items for each id sent via batched items; batches and in parallel
     ///
     /// Alternative to calling by_item on each id separately. 
     /// Returns `None` if that id is not in the database
@@ -644,11 +627,12 @@ impl<D: Distance> Reader<D> {
     /// # Examples
     /// ```no_run
     /// # use hannoy::{Reader, distances::Euclidean};
-    /// # use heed::{Env, WithoutTLs};
-    /// # let (reader, env): (Reader<Euclidean>, Env<WithoutTLs>) = todo!();
-    /// reader.par_by_items(&env, &[5, 6, 7], 10, 200);
+    /// # use heed::{Env, WithoutTls};
+    /// # let (reader, env): (Reader<Euclidean>, Env<WithoutTls>) = todo!();
+    /// reader.by_items(&env, &[5, 6, 7], 10, 200);
+    /// ```
 
-    pub fn par_by_items(&self, env: &Env<WithoutTls>, items: &[ItemId], 
+    pub fn by_items(&self, env: &Env<WithoutTls>, items: &[ItemId], 
                         n: usize, ef_search: usize) -> Result<Vec<Option<Searched>>>  where D: Sync, {
         
         use rayon::prelude::*;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import numpy as np
 
 import hannoy
 from hannoy import Metric
@@ -16,3 +17,13 @@ def db(tmp_path: Path):
         writer.add_item(2, [0.0, 0.0, 1.0])
 
     yield db
+
+@pytest.fixture(scope="function")
+def array_db(tmp_path: Path) -> hannoy.Database:
+    db = hannoy.Database(tmp_path, Metric.EUCLIDEAN)
+    vectors = np.array(
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32
+    )
+    with db.writer(3, m=4, ef=10) as writer:
+        writer.add_items([0, 1, 2], vectors)
+    return db

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -9,16 +9,6 @@ from hannoy import Metric, Reader
 
 
 @pytest.fixture(scope="function")
-def array_db(tmp_path: Path) -> hannoy.Database:
-    db = hannoy.Database(tmp_path, Metric.EUCLIDEAN)
-    vectors = np.array(
-        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32
-    )
-    with db.writer(3, m=4, ef=10) as writer:
-        writer.add_items([0, 1, 2], vectors)
-    return db
-
-
 def test_add_items_from_numpy_array(array_db: hannoy.Database) -> None:
     reader: Reader = array_db.reader(0)
     assert reader.by_vec([1.0, 0.0, 0.0], n=1) == [(0, 0.0)]

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import hannoy
+from hannoy import Reader
+
+def test_by_items_matches_by_item(array_db: hannoy.Database) -> None:
+    reader: Reader = array_db.reader(0)
+    batch = reader.by_items([1, 2, 3], n = 2, ef_search = 10)
+    per_item = [reader.by_item(i, n = 2, ef_search= 10) for i in (1, 2, 3)]
+    assert batch == per_item
+
+def test_by_items_batches_query(array_db: hannoy.Database) -> None:
+    reader: Reader = array_db.reader(0)
+    res = reader.by_items([0, 1, 2], n = 2, ef_search = 10)
+    assert(len(res)) == 3
+    assert [sorted(i for i, _ in row) for row in res] == [[1, 2], [0, 2], [0, 1]]
+
+
+
+def test_by_items_batches_queries(array_db: hannoy.Database) -> None:
+    reader: Reader = array_db.reader(0)
+    res = reader.by_items([0, 1], n=2, ef_search=10)
+    assert len(res) == 2
+    assert [sorted(i for i, _ in row) for row in res] == [[1, 2], [0, 2]]
+
+
+def test_by_items_none_for_missing_id(array_db: hannoy.Database) -> None:
+    reader: Reader = array_db.reader(0)
+    res = reader.by_items([0, 999], n=2, ef_search=10)
+
+    assert res[0] is not None
+    assert res[1] is None
+
+
+def test_by_items_preserves_order_with_missing(array_db: hannoy.Database) -> None:
+    reader: Reader = array_db.reader(0)
+    res = reader.by_items([0, 999, 1], n=2, ef_search=10)
+    assert len(res) == 3
+    assert res[0] is not None
+    assert res[1] is None
+    assert res[2] is not None
+
+
+def test_by_items_duplicate_ids(array_db: hannoy.Database) -> None:
+    reader: Reader = array_db.reader(0)
+    res = reader.by_items([0, 0, 1], n=2, ef_search=10)
+    assert len(res) == 3
+    assert res[0] == res[1]
+    assert res[0] == reader.by_item(0, n=2, ef_search=10)
+
+
+def test_by_items_empty(array_db: hannoy.Database) -> None:
+    reader: Reader = array_db.reader(0)
+    assert reader.by_items([], n=2, ef_search=10) == []


### PR DESCRIPTION
This draft PR brings in the `by_items` feature to allow batch querying. Current approach is more of a sequential approach. It is just going through a loop over `by_item` for each id. However, since the searches are all independent, I am working on trying to parallelize it to make it more efficient.  